### PR TITLE
solution for backslash escaping problem

### DIFF
--- a/pywurfl/wurflprocessor.py
+++ b/pywurfl/wurflprocessor.py
@@ -61,7 +61,7 @@ class DeviceHandler(object):
         @type device: elementtree.Element
         """
 
-        self.devua = device.attrib[u"user_agent"]
+        self._devua = device.attrib[u"user_agent"]
         self.devid = device.attrib[u"id"]
         self.parent = device.attrib[u"fall_back"]
         if (u"actual_device_root" in device.attrib and
@@ -70,6 +70,15 @@ class DeviceHandler(object):
         else:
             self.actual_device_root = False
         self.capabilities = {}
+
+    @property
+    def devua(self):
+        #BackslashEscaped
+        return self._devua.replace("\\", "\\\\")
+
+    @devua.setter
+    def devua(self, value):
+        self._devua = value
 
 
 class WurflProcessor(object):


### PR DESCRIPTION
When I refessed wurfl device python code with "1.7.1.0 released, db.scientiamobile.com - 2016-04-04 10:46:57" after when i try to use the generated wurfl.py i got the following error 
`
Traceback (most recent call last):
  File "test.py", line 3, in <module>
    from wurfl import devices
  File "/home/ubuntu/.../wurfl.py", line 17222
    devices.devids[ur'''asus_eee_pad_tf101_ver1_subuawimax'''] = devclass(devices.devids[ur'''asus_eee_pad_tf101_ver1'''], ur'''asus_eee_pad_tf101_ver1_subuawimax''', ur'''Mozilla/5.0 (Linux; U; Android 3.2.1; pt-br; TF101-WiMAX Build/HTK75) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.13 \''', False, {ur'''device_os_version''':ur'''3.2''',ur'''model_extra_info''':ur'''with WiMAX'''})

SyntaxError: invalid syntax
`
Then I fix it in my fork, please check it, and merge, maybe it could be useful for others.
Anyway thanks your module.
Szabi
